### PR TITLE
Added a try/finally case for safety.

### DIFF
--- a/notebooks/road_following.ipynb
+++ b/notebooks/road_following.ipynb
@@ -162,12 +162,15 @@
     "\n",
     "car.throttle = 0.15\n",
     "\n",
-    "while True:\n",
-    "    image = camera.read()\n",
-    "    image = preprocess(image).half()\n",
-    "    output = model_trt(image).detach().cpu().numpy().flatten()\n",
-    "    x = float(output[0])\n",
-    "    car.steering = x * STEERING_GAIN + STEERING_BIAS"
+    "try:\n"
+    "    while True:\n",
+    "        image = camera.read()\n",
+    "        image = preprocess(image).half()\n",
+    "        output = model_trt(image).detach().cpu().numpy().flatten()\n",
+    "        x = float(output[0])\n",
+    "        car.steering = x * STEERING_GAIN + STEERING_BIAS\n"
+    "finally:\n"
+    "    car.throttle = 0.0\n"
    ]
   }
  ],


### PR DESCRIPTION
Because the vehicle drives autonomously in the road_following.ipynb example, it is imperative to add safety features to it. As of right now, the only way to stop the vehicle is to send another car.throttle = 0 command. Stopping an autonomous vehicle under the duress of unexpected behavior can cause an individual to not think straight and therefore not realize that they can send the stopping command. Rather, the most common reaction would be to try and stop the kernel, unfortunately this still leaves the vehicle running with its last state. This is remedied by including the try/finally case which will guarantee that the vehicle comes to a stop if the infinite loop is interrupted.